### PR TITLE
removes extra line in installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ With [rustup](https://www.rust-lang.org/install.html) installed:
 ```sh
 $ rustup update nightly
 $ rustup target add wasm32-unknown-unknown --toolchain nightly
-$ rustc +nightly --target wasm32-unknown-unknown "$target" --crate-type=cdylib
 $ cargo install --git https://github.com/alexcrichton/wasm-gc
 ```
 ```sh


### PR DESCRIPTION
removes `$ rustc +nightly --target wasm32-unknown-unknown "$target" --crate-type=cdylib` from the installation steps in the readme.

I was running the rustup installation steps line-by-line, but that line causes an error in my terminal. I think it is used in `scripts/build.sh` and not something the user is meant to run manually.

Skipping over that line allowed me to install `rustify` successfully 🎉

Thanks!! 🌴 