### PR TITLE
Support rest spread & fix #8

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,6 +1,7 @@
 var StringDecoder = require('string_decoder').StringDecoder
 var mapLimit = require('map-limit')
 var through = require('through2')
+var acorn = require('acorn-node')
 var falafel = require('falafel')
 var mkdirp = require('mkdirp')
 var path = require('path')
@@ -43,8 +44,8 @@ function transform (filename, opts) {
     try {
       // We need to acquire the module name first, before we can proceed to
       // parse all the things.
-      var ast = falafel(src, { ecmaVersion: 8 }, identifyModuleName)
-      ast = falafel(ast.toString(), { ecmaVersion: 8 }, extractNodes)
+      var ast = falafel(src, { parser: acorn }, identifyModuleName)
+      ast = falafel(ast.toString(), { parser: acorn }, extractNodes)
     } catch (err) {
       return self.emit('error', err)
     }
@@ -78,12 +79,7 @@ function transform (filename, opts) {
           buf.forEach((c) => center.push(c))
           var str = `new Uint8Array(${JSON.stringify(center)})`
 
-          var parentNodeType = val.node.parent.type
-          var lolSemicolon = parentNodeType === 'VariableDeclarator' ||
-            parentNodeType === 'AssignmentExpression'
-            ? ''
-            : ';'
-          val.node.update(lolSemicolon + str)
+          val.node.update(str)
           done()
         })
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "standard && node test/index.js"
   },
   "dependencies": {
+    "acorn-node": "^1.3.0",
     "falafel": "^2.1.0",
     "map-limit": "0.0.1",
     "mkdirp": "^0.5.1",

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,3 @@
 require('./rust')
 require('./external')
+require('./syntax')

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -1,0 +1,15 @@
+var test = require('tape')
+var path = require('path')
+var vm = require('vm')
+var browserify = require('browserify')
+var rustify = require('../')
+
+test('syntax', function (t) {
+  t.plan(3)
+  browserify(path.join(__dirname, 'syntax/main.js'))
+    .transform(rustify)
+    .bundle(function (err, src) {
+      t.ifError(err)
+      vm.runInNewContext(src, { T: t })
+    })
+})

--- a/test/syntax/extern.rs
+++ b/test/syntax/extern.rs
@@ -1,0 +1,2 @@
+#[no_mangle]
+pub fn multiple() -> i32 { 20 }

--- a/test/syntax/main.js
+++ b/test/syntax/main.js
@@ -1,0 +1,24 @@
+var rust = require('rustify')
+
+var obj = { ...null }
+var wasm = rust`
+  #[no_mangle]
+  pub fn with_semi() -> i32 { 10 }
+`;
+
+console.log
+rust`#[no_mangle] pub fn should_not_call_console_log() -> () {}`
+
+instantiate(rust('./extern.rs'))
+
+WebAssembly.instantiate(wasm, {}).then(function (res) {
+  var exports = res.instance.exports
+  T.equal(exports.with_semi(), 10)
+}).catch(T.fail)
+
+function instantiate (bin) {
+  WebAssembly.instantiate(bin, {}).then(function (res) {
+    var exports = res.instance.exports
+    T.equal(exports.multiple(), 20)
+  }).catch(T.fail)
+}


### PR DESCRIPTION
Use acorn-node so we support new syntax like object rest spread
Remove the semicolon code because it was outputting invalid code and it's not necessary here